### PR TITLE
Update and rename NotfoundResponse.php to NotFoundResponse.php

### DIFF
--- a/src/Response/NotFoundResponse.php
+++ b/src/Response/NotFoundResponse.php
@@ -21,7 +21,7 @@ use Slim\Http\Headers;
 use Slim\Http\Response;
 use Slim\Http\Stream;
 
-class NotfoundResponse extends Response
+class NotFoundResponse extends Response
 {
     public function __construct($message, $status = 404)
     {


### PR DESCRIPTION
The name of the class should be NotFoundResponse to be concordated with the rest of the project. Isn't?